### PR TITLE
Create a new DomainQuery instance for each query

### DIFF
--- a/aql.js
+++ b/aql.js
@@ -168,9 +168,15 @@ class DomainQuery {
 }
 
 module.exports = {
-    items: new DomainQuery('items'),
-    builds: new DomainQuery('builds'),
-    archives: new DomainQuery('archive.entries'),
+    get items() {
+        return new DomainQuery('items');
+    },
+    get builds() {
+        return new DomainQuery('builds');
+    },
+    get archives() {
+        return new DomainQuery('archive.entries');
+    },
     config: conf => {
         let def = Object.assign({
             method: 'POST',

--- a/test/test.js
+++ b/test/test.js
@@ -33,5 +33,9 @@ describe('items', function () {
             // assert.deepEqual(aql.query("dafs"), err);
         });
 
+        it('should create a new DomainQuery instance for each query', () => {
+            assert.equal(aql.items    .find().include('name').query, 'items.find().include("name")');
+            assert.equal(aql.items    .find().include('repo').query, 'items.find().include("repo")');
+        });
     });
 });


### PR DESCRIPTION
Upon multiple queries to items/builds/archives the previous
DomainQuery would be used, which would include the query properties.
This fix creates a new instance of DomainQuery for every call,
so values from previous queries will not leak into the new one.
API usage stays the same by use of getters.
fixes #1